### PR TITLE
fix: make sure conversion 7/8 work with flags BIT 2 set

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,49 @@
+{
+    "name": "Jupyter Dev Container",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.12",
+    "features": {
+        "docker-in-docker": "latest"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+				"editorconfig.editorconfig",
+                "github.vscode-pull-request-github",
+                "github.vscode-github-actions",
+                "ms-toolsai.python-ds-extension-pack",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-python.flake8",
+                "ms-python.black-formatter",
+                "ms-python.isort",
+                "ms-python.pylint",
+				"ms-vsliveshare.vsliveshare",
+				"ryanluker.vscode-coverage-gutters",
+                "streetsidesoftware.code-spell-checker",
+                "ms-vscode.live-server",
+                "GitHub.copilot"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "black-formatter.path": [
+                    "/usr/local/py-utils/bin/black"
+                ],
+                "pylint.path": [
+                    "/usr/local/py-utils/bin/pylint"
+                ],
+                "flake8.path": [
+                    "/usr/local/py-utils/bin/flake8"
+                ],
+                "isort.path": [
+                    "/usr/local/py-utils/bin/isort"
+                ],
+                "terminal.integrated.shell.linux": "/bin/bash"
+            }
+        }
+    },
+    "postCreateCommand": "python -m pip install --upgrade pip && pip install coverage isort jupyterlab odsbox[exd-data] grpcio grpcio-tools pandas asammdf",
+    "forwardPorts": [
+        8888
+    ],
+    "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 __pycache__/
 /data/examples/internal_test_files/
+.coverage

--- a/external_data_reader.py
+++ b/external_data_reader.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, unquote
 from urllib.request import url2pathname
 
 from asammdf import MDF
+from asammdf.blocks.v4_blocks import Channel, ChannelConversion
 import grpc
 
 # pylint: disable=E1101
@@ -22,42 +23,45 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
     This class implements the ASAM ODS EXD API to read MDF4 files.
     """
 
-    def Open(self, identifier: exd_api.Identifier, context: dict) -> exd_api.Handle:
+    def Open(self, identifier: exd_api.Identifier, context: grpc.ServicerContext) -> exd_api.Handle:
         """
         Signals an open access to an resource. The server will call `close`later on.
 
         :param exd_api.Identifier identifier: Contains parameters and file url
-        :param dict context: Additional parameters from grpc
-        :raises ValueError: If file does not exist
+        :param grpc.ServicerContext context:  Additional parameters from grpc
+        :raises grpc.RpcError: If file does not exist
         :return exd_api.Handle: Handle to the opened file.
         """
         file_path = Path(self.__get_path(identifier.url))
         if not file_path.is_file():
-            raise ValueError(f'File "{identifier.url}" not accessible from plugin.')
+            context.abort(grpc.StatusCode.NOT_FOUND, f"File '{
+                          identifier.url}' not found.")
 
         connection_id = self.__open_mdf(identifier)
 
         rv = exd_api.Handle(uuid=connection_id)
         return rv
 
-    def Close(self, handle: exd_api.Handle, context: dict) -> exd_api.Empty:
+    def Close(self, handle: exd_api.Handle, context: grpc.ServicerContext) -> exd_api.Empty:
         """
         Close resource opened before and signal the plugin that it is no longer used.
 
         :param exd_api.Handle handle: Handle to a resource returned before.
-        :param dict context: Additional parameters from grpc.
+        :param grpc.ServicerContext context:  Additional parameters from grpc.
         :return exd_api.Empty: Empty object.
         """
         self.__close_mdf(handle)
         return exd_api.Empty()
 
-    def GetStructure(self, structure_request: exd_api.StructureRequest, context: dict) -> exd_api.StructureResult:
+    def GetStructure(self,
+                     structure_request: exd_api.StructureRequest,
+                     context: grpc.ServicerContext) -> exd_api.StructureResult:
         """
         Get the structure of the file returned as file-group-channel hierarchy.
 
         :param exd_api.StructureRequest structure_request: Defines what to extract from the file structure.
-        :param dict context: Additional parameters from grpc.
-        :raises NotImplementedError: If advanced features are requested.
+        :param grpc.ServicerContext context:  Additional parameters from grpc.
+        :raises grpc.RpcError: If advanced features are requested.
         :return exd_api.StructureResult: The structure of the opened file.
         """
         if (
@@ -65,16 +69,16 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
             or structure_request.suppress_attributes
             or 0 != len(structure_request.channel_names)
         ):
-            context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-            context.set_details("Method not implemented!")
-            raise NotImplementedError("Method not implemented!")
+            context.abort(grpc.StatusCode.UNIMPLEMENTED,
+                          "Method not implemented!")
 
         identifier = self.connection_map[structure_request.handle.uuid]
         mdf4 = self.__get_mdf(structure_request.handle)
 
         rv = exd_api.StructureResult(identifier=identifier)
         rv.name = Path(identifier.url).name
-        rv.attributes.variables["start_time"].string_array.values.append(mdf4.start_time.strftime("%Y%m%d%H%M%S%f"))
+        rv.attributes.variables["start_time"].string_array.values.append(
+            mdf4.start_time.strftime("%Y%m%d%H%M%S%f"))
 
         for group_index, group in enumerate(mdf4.groups):
 
@@ -83,7 +87,8 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
             new_group.id = group_index
             new_group.total_number_of_channels = len(group.channels)
             new_group.number_of_rows = group.channel_group.cycles_nr
-            new_group.attributes.variables["description"].string_array.values.append(group.channel_group.comment)
+            new_group.attributes.variables["description"].string_array.values.append(
+                group.channel_group.comment)
 
             for channel_index, channel in enumerate(group.channels):
                 new_channel = exd_api.StructureResult.Channel()
@@ -92,38 +97,38 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
                 new_channel.data_type = self.__get_channel_data_type(channel)
                 new_channel.unit_string = channel.unit
                 if channel.comment is not None and "" != channel.comment:
-                    new_channel.attributes.variables["description"].string_array.values.append(channel.comment)
+                    new_channel.attributes.variables["description"].string_array.values.append(
+                        channel.comment)
                 if 0 == channel_index:
-                    new_channel.attributes.variables["independent"].long_array.values.append(1)
+                    new_channel.attributes.variables["independent"].long_array.values.append(
+                        1)
                 new_group.channels.append(new_channel)
 
             rv.groups.append(new_group)
 
         return rv
 
-    def GetValues(self, values_request: exd_api.ValuesRequest, context: dict) -> exd_api.ValuesResult:
+    def GetValues(self, values_request: exd_api.ValuesRequest, context: grpc.ServicerContext) -> exd_api.ValuesResult:
         """
         Retrieve channel/signal data identified by `values_request`.
 
         :param exd_api.ValuesRequest values_request: Defines the group and its channels to be retrieved.
-        :param dict context: Additional grpc parameters.
-        :raises NotImplementedError: If unknown data type is accessed.
+        :param grpc.ServicerContext context:  Additional grpc parameters.
+        :raises grpc.RpcError: If unknown data type is accessed.
         :return exd_api.ValuesResult: The chunk of bulk data.
         """
         mdf4 = self.__get_mdf(values_request.handle)
 
         if values_request.group_id < 0 or values_request.group_id >= len(mdf4.groups):
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details(f"Invalid group id {values_request.group_id}!")
-            raise NotImplementedError(f"Invalid group id {values_request.group_id}!")
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT,
+                          f"Invalid group id {values_request.group_id}!")
 
         group = mdf4.groups[values_request.group_id]
 
         nr_of_rows = group.channel_group.cycles_nr
         if values_request.start > nr_of_rows:
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details(f"Channel start index {values_request.start} out of range!")
-            raise NotImplementedError(f"Channel start index {values_request.start} out of range!")
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT,
+                          f"Channel start index {values_request.start} out of range!")
 
         end_index = values_request.start + values_request.limit
         if end_index >= nr_of_rows:
@@ -132,10 +137,10 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
         channels_to_load = []
         for channel_id in values_request.channel_ids:
             if channel_id >= len(group.channels):
-                context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                context.set_details(f"Invalid channel id {channel_id}!")
-                raise NotImplementedError(f"Invalid channel id {channel_id}!")
-            channels_to_load.append((None, values_request.group_id, channel_id))
+                context.abort(grpc.StatusCode.INVALID_ARGUMENT,
+                              f"Invalid channel id {channel_id}!")
+            channels_to_load.append(
+                (None, values_request.group_id, channel_id))
 
         data = mdf4.select(
             channels_to_load,
@@ -148,11 +153,12 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
         if len(data) != len(values_request.channel_ids):
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             context.set_details(
-                f"Number read {len(data)} does not match requested channel count {len(values_request.channel_ids)} in {mdf4.name.name}!"
+                f"Number read {len(data)} does not match requested channel count {
+                    len(values_request.channel_ids)} in {mdf4.name.name}!"
             )
-            raise NotImplementedError(
-                f"Number read {len(data)} does not match requested channel count {len(values_request.channel_ids)} in {mdf4.name.name}!"
-            )
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT,
+                          f"Number read {len(data)} does not match requested channel count {
+                              len(values_request.channel_ids)} in {mdf4.name.name}!")
 
         rv = exd_api.ValuesResult(id=values_request.group_id)
         for signal_index, signal in enumerate(data, start=0):
@@ -195,43 +201,55 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
                 new_channel_values.values.string_array.values[:] = section
             elif channel_datatype == ods.DataTypeEnum.DT_BYTESTR:
                 for item in section:
-                    new_channel_values.values.bytestr_array.values.append(item.tobytes())
+                    new_channel_values.values.bytestr_array.values.append(
+                        item.tobytes())
             else:
                 raise NotImplementedError(
-                    f"Unknown np datatype {section.dtype} for type {channel_datatype} in {mdf4.name.name}!"
+                    f"Unknown np datatype {section.dtype} for type {
+                        channel_datatype} in {mdf4.name.name}!"
                 )
 
             rv.channels.append(new_channel_values)
 
         return rv
 
-    def GetValuesEx(self, request: exd_api.ValuesExRequest, context: dict) -> exd_api.ValuesExResult:
+    def GetValuesEx(self, request: exd_api.ValuesExRequest, context: grpc.ServicerContext) -> exd_api.ValuesExResult:
         """
         Method to access virtual groups and channels. Currently not supported by the plugin
 
         :param exd_api.ValuesExRequest request: Defines virtual groups and channels to be accessed.
-        :param dict context: Additional grpc parameters.
-        :raises NotImplementedError: Currently not implemented. Only needed for very advanced use.
+        :param grpc.ServicerContext context:  Additional grpc parameters.
+        :raises grpc.RpcError: Currently not implemented. Only needed for very advanced use.
         :return exd_api.ValuesExResult: Bulk values requested.
         """
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.abort(grpc.StatusCode.UNIMPLEMENTED,
+                      "Method not implemented!")
 
-    def __get_channel_data_type(self, channel):
+    def __get_channel_data_type(self, channel: Channel) -> ods.DataTypeEnum:
         rv = self.__get_channel_data_type_base(channel)
         if channel.conversion is not None:
+            rv = self.__get_conversion_data_type(rv, channel.conversion)
+        return rv
+
+    def __get_conversion_data_type(self, rv: ods.DataTypeEnum,  conversion: ChannelConversion) -> ods.DataTypeEnum:
+        if conversion is not None:
             if ods.DataTypeEnum.DT_STRING == rv:
-                if 9 == channel.conversion.conversion_type:
+                if 9 == conversion.conversion_type:
                     # text to value tabular look-up
                     return ods.DataTypeEnum.DT_DOUBLE
-            elif channel.conversion.conversion_type in [1, 2, 3, 4, 5]:
+            elif conversion.conversion_type in [1, 2, 3, 4, 5]:
                 return ods.DataTypeEnum.DT_DOUBLE
-            elif channel.conversion.conversion_type in [7, 8]:
+            elif conversion.conversion_type in [7, 8]:
+                if conversion.flags & 4 and conversion.referenced_blocks is not None:
+                    # Status string flag is set
+                    # the actual conversion rule is given in CCBLOCK referenced by default value.
+                    return self.__get_conversion_data_type(rv, conversion.referenced_blocks.get(
+                        'default_addr'))
+                    # conversion.default_addr
                 return ods.DataTypeEnum.DT_STRING
         return rv
 
-    def __get_channel_data_type_base(self, channel):
+    def __get_channel_data_type_base(self, channel: Channel) -> ods.DataTypeEnum:
         # [width="100",options="header"]
         # |====================
         # | number | cn_bit_count | DataTypeEnum | description
@@ -312,37 +330,38 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
         self.file_map = {}
         self.lock = threading.Lock()
 
-    def __get_id(self, identifier):
+    def __get_id(self, identifier: exd_api.Identifier) -> str:
         self.connect_count = self.connect_count + 1
         rv = str(self.connect_count)
         self.connection_map[rv] = identifier
         return rv
 
-    def __uri_to_path(self, uri):
+    def __uri_to_path(self, uri: str) -> str:
         parsed = urlparse(uri)
         host = f"{os.path.sep}{os.path.sep}{parsed.netloc}{os.path.sep}"
         return os.path.normpath(os.path.join(host, url2pathname(unquote(parsed.path))))
 
-    def __get_path(self, file_url):
+    def __get_path(self, file_url: str) -> str:
         final_path = self.__uri_to_path(file_url)
         return final_path
 
-    def __open_mdf(self, identifier):
+    def __open_mdf(self, identifier: exd_api.Identifier) -> str:
         with self.lock:
             identifier.parameters
             connection_id = self.__get_id(identifier)
             connection_url = self.__get_path(identifier.url)
             if connection_url not in self.file_map:
-                self.file_map[connection_url] = {"mdf4": MDF(connection_url), "ref_count": 0}
+                self.file_map[connection_url] = {
+                    "mdf4": MDF(connection_url), "ref_count": 0}
             self.file_map[connection_url]["ref_count"] = self.file_map[connection_url]["ref_count"] + 1
             return connection_id
 
-    def __get_mdf(self, handle):
+    def __get_mdf(self, handle: exd_api.Handle) -> MDF:
         identifier = self.connection_map[handle.uuid]
         connection_url = self.__get_path(identifier.url)
         return self.file_map[connection_url]["mdf4"]
 
-    def __close_mdf(self, handle):
+    def __close_mdf(self, handle: exd_api.Handle):
         with self.lock:
             identifier = self.connection_map[handle.uuid]
             connection_url = self.__get_path(identifier.url)
@@ -351,28 +370,4 @@ class ExternalDataReader(ods_external_data_pb2_grpc.ExternalDataReader):
             else:
                 self.file_map[connection_url]["mdf4"].close()
                 del self.file_map[connection_url]
-
-
-if __name__ == "__main__":
-
-    from google.protobuf.json_format import MessageToJson
-
-    external_data_reader = ExternalDataReader()
-
-    exd_api_handle = external_data_reader.Open(
-        exd_api.Identifier(url="file://C:/build/asammdf/data/pendulum_1686037830.mf4"), None
-    )
-    exd_api_request = exd_api.StructureRequest(handle=exd_api_handle)
-    exd_api_structure = external_data_reader.GetStructure(exd_api_request, None)
-    print(MessageToJson(exd_api_structure))
-
-    print(
-        MessageToJson(
-            external_data_reader.GetValues(
-                exd_api.ValuesRequest(
-                    handle=exd_api_handle, group_id=0, channel_ids=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], start=0, limit=10
-                ),
-                None,
-            )
-        )
-    )
+            del self.connection_map[handle.uuid]

--- a/test/mock_servicer_context.py
+++ b/test/mock_servicer_context.py
@@ -1,0 +1,78 @@
+
+import grpc
+
+
+class MockServicerContext(grpc.ServicerContext):
+    def __init__(self):
+        self._code = None
+        self._details = None
+
+    def cancel(self):
+        pass
+
+    def is_cancelled(self):
+        return False
+
+    def set_code(self, code):
+        self._code = code
+
+    def set_details(self, details):
+        self._details = details
+
+    def abort(self, code, details):
+        self.set_code(code)
+        self.set_details(details)
+        raise grpc.RpcError(details)
+
+    def abort_with_status(self, status):
+        self.set_code(status.code())
+        self.set_details(status.details())
+        raise grpc.RpcError(status.details())
+
+    def is_active(self):
+        return True
+
+    def time_remaining(self):
+        return 1000
+
+    def add_callback(self, callback):
+        pass
+
+    def invocation_metadata(self):
+        return []
+
+    def peer(self):
+        return "peer"
+
+    def send_initial_metadata(self, initial_metadata):
+        pass
+
+    def set_trailing_metadata(self, trailing_metadata):
+        pass
+
+    def auth_context(self):
+        return {}
+
+    def set_compression(self, compression):
+        pass
+
+    def disable_next_message_compression(self):
+        pass
+
+    def initial_metadata(self):
+        return []
+
+    def trailing_metadata(self):
+        return []
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+    def peer_identities(self):
+        return super().peer_identities()
+
+    def peer_identity_key(self):
+        return super().peer_identity_key()

--- a/test/test_example_files.py
+++ b/test/test_example_files.py
@@ -1,19 +1,17 @@
 # Prepare python to use GRPC interface:
 # python -m grpc_tools.protoc --proto_path=proto_src --pyi_out=. --python_out=. --grpc_python_out=. ods.proto ods_external_data.proto
-import sys, os
 
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
-
-import logging
-import pathlib
-import unittest
 from glob import glob
-
-# pylint: disable=E1101
-import ods_pb2 as ods
-import ods_external_data_pb2 as oed
+import unittest
+import pathlib
+import logging
+import os
 
 from external_data_reader import ExternalDataReader
+import ods_external_data_pb2 as oed
+import ods_pb2 as ods
+
+# pylint: disable=E1101
 
 
 class TestExampleFiles(unittest.TestCase):
@@ -21,96 +19,112 @@ class TestExampleFiles(unittest.TestCase):
 
     def __load_structure(self, example_file_uri):
         service = ExternalDataReader()
-        handle = service.Open(oed.Identifier(url=example_file_uri, parameters=""), None)
+        handle = service.Open(oed.Identifier(
+            url=example_file_uri, parameters=""), None)
         try:
-            structure = service.GetStructure(oed.StructureRequest(handle=handle), None)
+            structure = service.GetStructure(
+                oed.StructureRequest(handle=handle), None)
             return structure
         finally:
             service.Close(handle, None)
 
     def test_files(self):
         """test loops over all files and checks if values do match info in structure"""
-        example_files_folder = pathlib.Path.joinpath(pathlib.Path(__file__).parent.resolve(), "..", "data", "examples")
-        example_files = [y for x in os.walk(example_files_folder) for y in glob(os.path.join(x[0], "*.mf4"))]
+        example_files_folder = pathlib.Path.joinpath(pathlib.Path(
+            __file__).parent.resolve(), "..", "data", "examples")
+        example_files = [y for x in os.walk(
+            example_files_folder) for y in glob(os.path.join(x[0], "*.mf4"))]
 
         failed = False
         for example_file in example_files:
-            example_file_uri = pathlib.Path(example_file).absolute().resolve().as_uri()
-            print(f"URI: {example_file_uri}")
+            example_file_uri = pathlib.Path(
+                example_file).absolute().resolve().as_uri()
             try:
-                self.log.info("Retrieve structure")
-                structure = self.__load_structure(example_file_uri)
-                self.assertNotEqual(structure.name, "")
-                self.assertNotEqual(structure.identifier.url, "")
-
-                self.log.info("Check bulk load")
-                service = ExternalDataReader()
-                handle = service.Open(oed.Identifier(url=example_file_uri, parameters=""), None)
-                try:
-                    for group in structure.groups:
-                        channel_ids = []
-                        for channel in group.channels:
-                            channel_ids.append(channel.id)
-                        values = service.GetValues(
-                            oed.ValuesRequest(
-                                handle=handle,
-                                group_id=group.id,
-                                start=0,
-                                limit=group.number_of_rows + 10,
-                                channel_ids=channel_ids,
-                            ),
-                            None,
-                        )
-                        for values_channel_index, values_channel in enumerate(values.channels):
-                            structure_channel = group.channels[values_channel_index]
-                            self.assertEqual(values_channel.id, structure_channel.id)
-                            self.assertEqual(values_channel.values.data_type, structure_channel.data_type)
-                            if ods.DataTypeEnum.DT_COMPLEX == values_channel.values.data_type:
-                                vals = values_channel.values.float_array.values
-                                self.assertEqual(len(vals), group.number_of_rows * 2)
-                            elif ods.DataTypeEnum.DT_DCOMPLEX == values_channel.values.data_type:
-                                vals = values_channel.values.double_array.values
-                                self.assertEqual(len(vals), group.number_of_rows * 2)
-                            elif ods.DataTypeEnum.DT_BYTE == values_channel.values.data_type:
-                                vals = values_channel.values.byte_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_SHORT == values_channel.values.data_type:
-                                vals = values_channel.values.long_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_LONG == values_channel.values.data_type:
-                                vals = values_channel.values.long_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_LONGLONG == values_channel.values.data_type:
-                                vals = values_channel.values.longlong_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_FLOAT == values_channel.values.data_type:
-                                vals = values_channel.values.float_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_DOUBLE == values_channel.values.data_type:
-                                vals = values_channel.values.double_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_STRING == values_channel.values.data_type:
-                                vals = values_channel.values.string_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_DATE == values_channel.values.data_type:
-                                vals = values_channel.values.string_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_BYTESTR == values_channel.values.data_type:
-                                vals = values_channel.values.bytestr_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            elif ods.DataTypeEnum.DT_BOOLEAN == values_channel.values.data_type:
-                                vals = values_channel.values.boolean_array.values
-                                self.assertEqual(len(vals), group.number_of_rows)
-                            else:
-                                self.assertFalse(True, f"Unknown type {values_channel.values.data_type}")
-                finally:
-                    service.Close(handle, None)
+                self.__check_file_including_bulk(example_file_uri)
             except Exception as e:
                 print(f"FAILED: {e}")
                 failed = True
 
         self.assertFalse(failed, "At least one file failed")
 
+    def test_file(self):
+        """Check a single file"""
+        example_file = pathlib.Path.joinpath(pathlib.Path(
+            __file__).parent.resolve(), "..", "data", "simple.mf4")
+        assert example_file.exists()
+        example_file_uri = pathlib.Path(
+            example_file).absolute().resolve().as_uri()
+        self.__check_file_including_bulk(example_file_uri)
 
-if __name__ == "__main__":
-    unittest.main()
+    def __check_file_including_bulk(self, example_file_uri):
+        print(f"URI: {example_file_uri}")
+        self.log.info("Retrieve structure")
+        structure = self.__load_structure(example_file_uri)
+        self.assertNotEqual(structure.name, "")
+        self.assertNotEqual(structure.identifier.url, "")
+
+        self.log.info("Check bulk load")
+        service = ExternalDataReader()
+        handle = service.Open(oed.Identifier(
+            url=example_file_uri, parameters=""), None)
+        try:
+            for group in structure.groups:
+                channel_ids = []
+                for channel in group.channels:
+                    channel_ids.append(channel.id)
+                values = service.GetValues(
+                    oed.ValuesRequest(
+                        handle=handle,
+                        group_id=group.id,
+                        start=0,
+                        limit=group.number_of_rows + 10,
+                        channel_ids=channel_ids,
+                    ),
+                    None,
+                )
+                for values_channel_index, values_channel in enumerate(values.channels):
+                    structure_channel = group.channels[values_channel_index]
+                    self.assertEqual(values_channel.id, structure_channel.id)
+                    self.assertEqual(
+                        values_channel.values.data_type, structure_channel.data_type)
+                    if ods.DataTypeEnum.DT_COMPLEX == values_channel.values.data_type:
+                        vals = values_channel.values.float_array.values
+                        self.assertEqual(len(vals), group.number_of_rows * 2)
+                    elif ods.DataTypeEnum.DT_DCOMPLEX == values_channel.values.data_type:
+                        vals = values_channel.values.double_array.values
+                        self.assertEqual(len(vals), group.number_of_rows * 2)
+                    elif ods.DataTypeEnum.DT_BYTE == values_channel.values.data_type:
+                        vals = values_channel.values.byte_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_SHORT == values_channel.values.data_type:
+                        vals = values_channel.values.long_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_LONG == values_channel.values.data_type:
+                        vals = values_channel.values.long_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_LONGLONG == values_channel.values.data_type:
+                        vals = values_channel.values.longlong_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_FLOAT == values_channel.values.data_type:
+                        vals = values_channel.values.float_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_DOUBLE == values_channel.values.data_type:
+                        vals = values_channel.values.double_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_STRING == values_channel.values.data_type:
+                        vals = values_channel.values.string_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_DATE == values_channel.values.data_type:
+                        vals = values_channel.values.string_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_BYTESTR == values_channel.values.data_type:
+                        vals = values_channel.values.bytestr_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    elif ods.DataTypeEnum.DT_BOOLEAN == values_channel.values.data_type:
+                        vals = values_channel.values.boolean_array.values
+                        self.assertEqual(len(vals), group.number_of_rows)
+                    else:
+                        self.assertFalse(True, f"Unknown type {
+                                         values_channel.values.data_type}")
+        finally:
+            service.Close(handle, None)

--- a/test/test_exd_api.py
+++ b/test/test_exd_api.py
@@ -1,31 +1,30 @@
 # Prepare python to use GRPC interface:
 # python -m grpc_tools.protoc --proto_path=proto_src --pyi_out=. --python_out=. --grpc_python_out=. ods.proto ods_external_data.proto
-import sys, os
-
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
-
 import logging
 import pathlib
 import unittest
 
+from google.protobuf.json_format import MessageToJson
 import ods_pb2 as ods
 import ods_external_data_pb2 as oed
 
-# pylint: disable=E1101
 from external_data_reader import ExternalDataReader
-from google.protobuf.json_format import MessageToJson
+
+# pylint: disable=E1101
 
 
 class TestStringMethods(unittest.TestCase):
     log = logging.getLogger(__name__)
 
     def _get_example_file_path(self, file_name):
-        example_file_path = pathlib.Path.joinpath(pathlib.Path(__file__).parent.resolve(), "..", "data", file_name)
+        example_file_path = pathlib.Path.joinpath(pathlib.Path(
+            __file__).parent.resolve(), "..", "data", file_name)
         return pathlib.Path(example_file_path).absolute().as_uri()
 
     def test_open(self):
         service = ExternalDataReader()
-        handle = service.Open(oed.Identifier(url=self._get_example_file_path("simple.mf4"), parameters=""), None)
+        handle = service.Open(oed.Identifier(
+            url=self._get_example_file_path("simple.mf4"), parameters=""), None)
         try:
             pass
         finally:
@@ -33,9 +32,11 @@ class TestStringMethods(unittest.TestCase):
 
     def test_structure(self):
         service = ExternalDataReader()
-        handle = service.Open(oed.Identifier(url=self._get_example_file_path("simple.mf4"), parameters=""), None)
+        handle = service.Open(oed.Identifier(
+            url=self._get_example_file_path("simple.mf4"), parameters=""), None)
         try:
-            structure = service.GetStructure(oed.StructureRequest(handle=handle), None)
+            structure = service.GetStructure(
+                oed.StructureRequest(handle=handle), None)
             self.assertEqual(structure.name, "simple.mf4")
             self.assertEqual(len(structure.groups), 1)
             self.assertEqual(structure.groups[0].number_of_rows, 563)
@@ -48,10 +49,12 @@ class TestStringMethods(unittest.TestCase):
 
     def test_get_values(self):
         service = ExternalDataReader()
-        handle = service.Open(oed.Identifier(url=self._get_example_file_path("simple.mf4"), parameters=""), None)
+        handle = service.Open(oed.Identifier(
+            url=self._get_example_file_path("simple.mf4"), parameters=""), None)
         try:
             values = service.GetValues(
-                oed.ValuesRequest(handle=handle, group_id=0, channel_ids=[0, 1, 2, 3], start=0, limit=4), None  #
+                oed.ValuesRequest(handle=handle, group_id=0, channel_ids=[
+                                  0, 1, 2, 3], start=0, limit=4), None  #
             )
             self.assertEqual(values.id, 0)
             self.assertEqual(len(values.channels), 4)
@@ -59,19 +62,19 @@ class TestStringMethods(unittest.TestCase):
             self.assertEqual(values.channels[1].id, 1)
             self.log.info(MessageToJson(values))
 
-            self.assertEqual(values.channels[0].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
+            self.assertEqual(
+                values.channels[0].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
             self.assertSequenceEqual(
-                values.channels[0].values.double_array.values, [0.0, 17905500.0, 30515300.0, 48317800.0]
+                values.channels[0].values.double_array.values, [
+                    0.0, 17905500.0, 30515300.0, 48317800.0]
             )
-            self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
+            self.assertEqual(
+                values.channels[1].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
             self.assertSequenceEqual(
                 values.channels[1].values.longlong_array.values,
-                [1686082945335777300, 1686082945353682800, 1686082945366292600, 1686082945384095100],
+                [1686082945335777300, 1686082945353682800,
+                    1686082945366292600, 1686082945384095100],
             )
 
         finally:
             service.Close(handle, None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_exd_api_datatypes.py
+++ b/test/test_exd_api_datatypes.py
@@ -1,38 +1,36 @@
 # Prepare python to use GRPC interface:
 # python -m grpc_tools.protoc --proto_path=proto_src --pyi_out=. --python_out=. --grpc_python_out=. ods.proto ods_external_data.proto
-import sys, os
-
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
-
-import logging
-import pathlib
-import unittest
-from datetime import datetime
-import tempfile
 from pathlib import Path
-
+import tempfile
+from datetime import datetime
+import unittest
 import numpy as np
-
-import ods_pb2 as ods
-import ods_external_data_pb2 as oed
-
-# pylint: disable=E1101
-from external_data_reader import ExternalDataReader
-from google.protobuf.json_format import MessageToJson
+import pathlib
+import logging
+import os
 
 from asammdf import MDF, Signal
+from google.protobuf.json_format import MessageToJson
+from external_data_reader import ExternalDataReader
+import ods_external_data_pb2 as oed
+import ods_pb2 as ods
+
+
+# pylint: disable=E1101
 
 
 class TestDataTypes(unittest.TestCase):
     log = logging.getLogger(__name__)
 
     def _get_example_file_path(self, file_name):
-        example_file_path = pathlib.Path.joinpath(pathlib.Path(__file__).parent.resolve(), "..", "data", file_name)
+        example_file_path = pathlib.Path.joinpath(pathlib.Path(
+            __file__).parent.resolve(), "..", "data", file_name)
         return pathlib.Path(example_file_path).absolute().resolve().as_uri()
 
     def test_data_type(self):
         with tempfile.TemporaryDirectory() as temporary_directory_name:
-            file_path = os.path.join(temporary_directory_name, "all_datatypes_test.mf4")
+            file_path = os.path.join(
+                temporary_directory_name, "all_datatypes_test.mf4")
 
             with MDF(version="4.10", file_comment="all_datatypes_test.mf4") as mdf4:
                 mdf4.start_time = datetime.now()
@@ -58,7 +56,8 @@ class TestDataTypes(unittest.TestCase):
                         unit="ns",
                     )
                 )
-                mdf4.append(sigs, comment="group_complex", common_timebase=True)
+                mdf4.append(sigs, comment="group_complex",
+                            common_timebase=True)
 
                 sigs = []
                 sigs.append(
@@ -172,9 +171,11 @@ class TestDataTypes(unittest.TestCase):
                 mdf4.save(file_path, compression=2, overwrite=True)
 
             service = ExternalDataReader()
-            handle = service.Open(oed.Identifier(url=Path(file_path).resolve().as_uri(), parameters=""), None)
+            handle = service.Open(oed.Identifier(
+                url=Path(file_path).resolve().as_uri(), parameters=""), None)
             try:
-                structure = service.GetStructure(oed.StructureRequest(handle=handle), None)
+                structure = service.GetStructure(
+                    oed.StructureRequest(handle=handle), None)
                 self.log.info(MessageToJson(structure))
 
                 self.assertEqual(structure.name, "all_datatypes_test.mf4")
@@ -188,30 +189,48 @@ class TestDataTypes(unittest.TestCase):
                 self.assertEqual(structure.groups[3].number_of_rows, 2)
                 self.assertEqual(len(structure.groups[3].channels), 2)
 
-                self.assertEqual(structure.groups[0].channels[1].data_type, ods.DataTypeEnum.DT_COMPLEX)
-                self.assertEqual(structure.groups[0].channels[2].data_type, ods.DataTypeEnum.DT_DCOMPLEX)
+                self.assertEqual(
+                    structure.groups[0].channels[1].data_type, ods.DataTypeEnum.DT_COMPLEX)
+                self.assertEqual(
+                    structure.groups[0].channels[2].data_type, ods.DataTypeEnum.DT_DCOMPLEX)
 
-                self.assertEqual(structure.groups[1].channels[1].data_type, ods.DataTypeEnum.DT_SHORT)
-                self.assertEqual(structure.groups[1].channels[2].data_type, ods.DataTypeEnum.DT_BYTE)
-                self.assertEqual(structure.groups[1].channels[3].data_type, ods.DataTypeEnum.DT_SHORT)
-                self.assertEqual(structure.groups[1].channels[4].data_type, ods.DataTypeEnum.DT_LONG)
-                self.assertEqual(structure.groups[1].channels[5].data_type, ods.DataTypeEnum.DT_LONG)
-                self.assertEqual(structure.groups[1].channels[6].data_type, ods.DataTypeEnum.DT_LONGLONG)
-                self.assertEqual(structure.groups[1].channels[7].data_type, ods.DataTypeEnum.DT_LONGLONG)
-                self.assertEqual(structure.groups[1].channels[8].data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertEqual(
+                    structure.groups[1].channels[1].data_type, ods.DataTypeEnum.DT_SHORT)
+                self.assertEqual(
+                    structure.groups[1].channels[2].data_type, ods.DataTypeEnum.DT_BYTE)
+                self.assertEqual(
+                    structure.groups[1].channels[3].data_type, ods.DataTypeEnum.DT_SHORT)
+                self.assertEqual(
+                    structure.groups[1].channels[4].data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertEqual(
+                    structure.groups[1].channels[5].data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertEqual(
+                    structure.groups[1].channels[6].data_type, ods.DataTypeEnum.DT_LONGLONG)
+                self.assertEqual(
+                    structure.groups[1].channels[7].data_type, ods.DataTypeEnum.DT_LONGLONG)
+                self.assertEqual(
+                    structure.groups[1].channels[8].data_type, ods.DataTypeEnum.DT_DOUBLE)
 
-                self.assertEqual(structure.groups[2].channels[1].data_type, ods.DataTypeEnum.DT_FLOAT)
-                self.assertEqual(structure.groups[2].channels[2].data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertEqual(
+                    structure.groups[2].channels[1].data_type, ods.DataTypeEnum.DT_FLOAT)
+                self.assertEqual(
+                    structure.groups[2].channels[2].data_type, ods.DataTypeEnum.DT_DOUBLE)
 
-                self.assertEqual(structure.groups[3].channels[1].data_type, ods.DataTypeEnum.DT_STRING)
+                self.assertEqual(
+                    structure.groups[3].channels[1].data_type, ods.DataTypeEnum.DT_STRING)
 
                 values = service.GetValues(
-                    oed.ValuesRequest(handle=handle, group_id=0, start=0, limit=2, channel_ids=[0, 1, 2]), None
+                    oed.ValuesRequest(
+                        handle=handle, group_id=0, start=0, limit=2, channel_ids=[0, 1, 2]), None
                 )
-                self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_COMPLEX)
-                self.assertSequenceEqual(values.channels[1].values.float_array.values, [1.0, 2.0, 3.0, 4.0])
-                self.assertEqual(values.channels[2].values.data_type, ods.DataTypeEnum.DT_DCOMPLEX)
-                self.assertSequenceEqual(values.channels[2].values.double_array.values, [5.0, 6.0, 7.0, 8.0])
+                self.assertEqual(
+                    values.channels[1].values.data_type, ods.DataTypeEnum.DT_COMPLEX)
+                self.assertSequenceEqual(
+                    values.channels[1].values.float_array.values, [1.0, 2.0, 3.0, 4.0])
+                self.assertEqual(
+                    values.channels[2].values.data_type, ods.DataTypeEnum.DT_DCOMPLEX)
+                self.assertSequenceEqual(
+                    values.channels[2].values.double_array.values, [5.0, 6.0, 7.0, 8.0])
 
                 values = service.GetValues(
                     oed.ValuesRequest(
@@ -219,45 +238,70 @@ class TestDataTypes(unittest.TestCase):
                     ),
                     None,
                 )
-                self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_SHORT)
-                self.assertSequenceEqual(values.channels[1].values.long_array.values, [-2, 4])
-                self.assertEqual(values.channels[2].values.data_type, ods.DataTypeEnum.DT_BYTE)
-                self.assertSequenceEqual(values.channels[2].values.byte_array.values, [2, 4])
-                self.assertEqual(values.channels[3].values.data_type, ods.DataTypeEnum.DT_SHORT)
-                self.assertSequenceEqual(values.channels[3].values.long_array.values, [-2, 4])
-                self.assertEqual(values.channels[4].values.data_type, ods.DataTypeEnum.DT_LONG)
-                self.assertSequenceEqual(values.channels[4].values.long_array.values, [2, 4])
-                self.assertEqual(values.channels[5].values.data_type, ods.DataTypeEnum.DT_LONG)
-                self.assertSequenceEqual(values.channels[5].values.long_array.values, [-2, 4])
-                self.assertEqual(values.channels[6].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
-                self.assertSequenceEqual(values.channels[6].values.longlong_array.values, [2, 4])
-                self.assertEqual(values.channels[7].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
-                self.assertSequenceEqual(values.channels[7].values.longlong_array.values, [-2, 4])
-                self.assertEqual(values.channels[8].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
-                self.assertSequenceEqual(values.channels[8].values.double_array.values, [2.0, 4.0])
-
-                values = service.GetValues(
-                    oed.ValuesRequest(handle=handle, group_id=2, start=0, limit=2, channel_ids=[0, 1, 2]), None
-                )
-                self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_FLOAT)
+                self.assertEqual(
+                    values.channels[1].values.data_type, ods.DataTypeEnum.DT_SHORT)
                 self.assertSequenceEqual(
-                    values.channels[1].values.float_array.values, [1.100000023841858, 1.2000000476837158]
-                )
-                self.assertEqual(values.channels[2].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
-                self.assertSequenceEqual(values.channels[2].values.double_array.values, [2.1, 2.2])
+                    values.channels[1].values.long_array.values, [-2, 4])
+                self.assertEqual(
+                    values.channels[2].values.data_type, ods.DataTypeEnum.DT_BYTE)
+                self.assertSequenceEqual(
+                    values.channels[2].values.byte_array.values, [2, 4])
+                self.assertEqual(
+                    values.channels[3].values.data_type, ods.DataTypeEnum.DT_SHORT)
+                self.assertSequenceEqual(
+                    values.channels[3].values.long_array.values, [-2, 4])
+                self.assertEqual(
+                    values.channels[4].values.data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertSequenceEqual(
+                    values.channels[4].values.long_array.values, [2, 4])
+                self.assertEqual(
+                    values.channels[5].values.data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertSequenceEqual(
+                    values.channels[5].values.long_array.values, [-2, 4])
+                self.assertEqual(
+                    values.channels[6].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
+                self.assertSequenceEqual(
+                    values.channels[6].values.longlong_array.values, [2, 4])
+                self.assertEqual(
+                    values.channels[7].values.data_type, ods.DataTypeEnum.DT_LONGLONG)
+                self.assertSequenceEqual(
+                    values.channels[7].values.longlong_array.values, [-2, 4])
+                self.assertEqual(
+                    values.channels[8].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertSequenceEqual(
+                    values.channels[8].values.double_array.values, [2.0, 4.0])
 
                 values = service.GetValues(
-                    oed.ValuesRequest(handle=handle, group_id=3, start=0, limit=2, channel_ids=[0, 1]), None
+                    oed.ValuesRequest(
+                        handle=handle, group_id=2, start=0, limit=2, channel_ids=[0, 1, 2]), None
                 )
-                self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_STRING)
-                self.assertSequenceEqual(values.channels[1].values.string_array.values, ["abc", "def"])
+                self.assertEqual(
+                    values.channels[1].values.data_type, ods.DataTypeEnum.DT_FLOAT)
+                self.assertSequenceEqual(
+                    values.channels[1].values.float_array.values, [
+                        1.100000023841858, 1.2000000476837158]
+                )
+                self.assertEqual(
+                    values.channels[2].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertSequenceEqual(
+                    values.channels[2].values.double_array.values, [2.1, 2.2])
+
+                values = service.GetValues(
+                    oed.ValuesRequest(handle=handle, group_id=3,
+                                      start=0, limit=2, channel_ids=[0, 1]), None
+                )
+                self.assertEqual(
+                    values.channels[1].values.data_type, ods.DataTypeEnum.DT_STRING)
+                self.assertSequenceEqual(
+                    values.channels[1].values.string_array.values, ["abc", "def"])
 
             finally:
                 service.Close(handle, None)
 
     def test_independent(self):
         with tempfile.TemporaryDirectory() as temporary_directory_name:
-            file_path = os.path.join(temporary_directory_name, "independent_test.mf4")
+            file_path = os.path.join(
+                temporary_directory_name, "independent_test.mf4")
 
             with MDF(version="4.10", file_comment="independent_test.mf4") as mdf4:
                 mdf4.start_time = datetime.now()
@@ -279,9 +323,11 @@ class TestDataTypes(unittest.TestCase):
                 mdf4.save(file_path, compression=2, overwrite=True)
 
             service = ExternalDataReader()
-            handle = service.Open(oed.Identifier(url=Path(file_path).resolve().as_uri(), parameters=""), None)
+            handle = service.Open(oed.Identifier(
+                url=Path(file_path).resolve().as_uri(), parameters=""), None)
             try:
-                structure = service.GetStructure(oed.StructureRequest(handle=handle), None)
+                structure = service.GetStructure(
+                    oed.StructureRequest(handle=handle), None)
                 self.log.info(MessageToJson(structure))
                 print(MessageToJson(structure))
 
@@ -291,34 +337,42 @@ class TestDataTypes(unittest.TestCase):
                 self.assertEqual(len(structure.groups[0].channels), 2)
 
                 self.assertEqual("time", structure.groups[0].channels[0].name)
-                self.assertEqual("int32_data", structure.groups[0].channels[1].name)
+                self.assertEqual(
+                    "int32_data", structure.groups[0].channels[1].name)
 
-                self.assertEqual(structure.groups[0].channels[0].data_type, ods.DataTypeEnum.DT_DOUBLE)
-                self.assertEqual(structure.groups[0].channels[1].data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertEqual(
+                    structure.groups[0].channels[0].data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertEqual(
+                    structure.groups[0].channels[1].data_type, ods.DataTypeEnum.DT_LONG)
 
-                self.assertTrue("independent" in structure.groups[0].channels[0].attributes.variables)
+                self.assertTrue(
+                    "independent" in structure.groups[0].channels[0].attributes.variables)
                 self.assertEqual(
                     1, structure.groups[0].channels[0].attributes.variables["independent"].long_array.values[0]
                 )
-                self.assertTrue("independent" not in structure.groups[0].channels[1].attributes.variables)
+                self.assertTrue(
+                    "independent" not in structure.groups[0].channels[1].attributes.variables)
 
-                self.assertTrue("description" not in structure.groups[0].channels[0].attributes.variables)
-                self.assertTrue("description" in structure.groups[0].channels[1].attributes.variables)
+                self.assertTrue(
+                    "description" not in structure.groups[0].channels[0].attributes.variables)
+                self.assertTrue(
+                    "description" in structure.groups[0].channels[1].attributes.variables)
                 self.assertEqual(
                     "int32 data",
                     structure.groups[0].channels[1].attributes.variables["description"].string_array.values[0],
                 )
 
                 values = service.GetValues(
-                    oed.ValuesRequest(handle=handle, group_id=0, start=0, limit=2, channel_ids=[0, 1]), None
+                    oed.ValuesRequest(handle=handle, group_id=0,
+                                      start=0, limit=2, channel_ids=[0, 1]), None
                 )
-                self.assertEqual(values.channels[0].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
-                self.assertSequenceEqual(values.channels[0].values.double_array.values, [0.0, 1.0])
-                self.assertEqual(values.channels[1].values.data_type, ods.DataTypeEnum.DT_LONG)
-                self.assertSequenceEqual(values.channels[1].values.long_array.values, [2, 4])
+                self.assertEqual(
+                    values.channels[0].values.data_type, ods.DataTypeEnum.DT_DOUBLE)
+                self.assertSequenceEqual(
+                    values.channels[0].values.double_array.values, [0.0, 1.0])
+                self.assertEqual(
+                    values.channels[1].values.data_type, ods.DataTypeEnum.DT_LONG)
+                self.assertSequenceEqual(
+                    values.channels[1].values.long_array.values, [2, 4])
             finally:
                 service.Close(handle, None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_external_data_reader.py
+++ b/test/test_external_data_reader.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+import os
+import tempfile
+import unittest
+from pathlib import Path
+import grpc
+from google.protobuf.json_format import MessageToJson
+
+from test.mock_servicer_context import MockServicerContext
+from asammdf import MDF
+from external_data_reader import ExternalDataReader
+import ods_external_data_pb2 as exd_api
+
+
+# pylint: disable=E1101
+
+
+class TestExternalDataReader(unittest.TestCase):
+
+    def setUp(self):
+        self.service = ExternalDataReader()
+        self.mock_context = MockServicerContext()
+
+    def test_open_existing_file(self):
+        # Create a temporary MDF file
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "test.mf4")
+            with MDF(version="4.10", file_comment="test.mf4") as mdf4:
+                mdf4.start_time = datetime.now()
+                mdf4.save(file_path, compression=2, overwrite=True)
+
+            identifier = exd_api.Identifier(
+                url=Path(file_path).resolve().as_uri(), parameters="")
+            handle = self.service.Open(identifier, None)
+            self.assertIsNotNone(handle.uuid)
+
+    def test_open_non_existing_file(self):
+        identifier = exd_api.Identifier(
+            url="file:///non_existing_file.mf4", parameters="")
+        with self.assertRaises(grpc.RpcError) as _:
+            self.service.Open(identifier, self.mock_context)
+
+        self.assertEqual(self.mock_context.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_simple_example(self):
+        main_file_path = Path.joinpath(
+            Path(__file__).parent.resolve(), "..", "data", "simple.mf4")
+
+        main_file_url = Path(main_file_path).absolute().resolve().as_uri()
+
+        main_external_data_reader = ExternalDataReader()
+
+        main_exd_api_handle = main_external_data_reader.Open(
+            exd_api.Identifier(url=main_file_url, parameters=""),
+            None
+        )
+        try:
+
+            main_exd_api_structure = main_external_data_reader.GetStructure(
+                exd_api.StructureRequest(handle=main_exd_api_handle), None)
+            print(MessageToJson(main_exd_api_structure))
+
+            print(
+                MessageToJson(
+                    main_external_data_reader.GetValues(
+                        exd_api.ValuesRequest(
+                            handle=main_exd_api_handle, group_id=0, channel_ids=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], start=0, limit=10
+                        ),
+                        None,
+                    )
+                )
+            )
+        finally:
+            main_external_data_reader.Close(main_exd_api_handle, None)
+
+    def test_close_mdf(self):
+        # Create a temporary MDF file
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "test.mf4")
+            with MDF(version="4.10", file_comment="test.mf4") as mdf4:
+                mdf4.start_time = datetime.now()
+                mdf4.save(file_path, compression=2, overwrite=True)
+
+            identifier = exd_api.Identifier(
+                url=Path(file_path).resolve().as_uri(), parameters="")
+            handle1 = self.service.Open(identifier, None)
+            self.assertIsNotNone(handle1.uuid)
+
+            handle2 = self.service.Open(identifier, None)
+            self.assertIsNotNone(handle2.uuid)
+
+            self.assertNotEqual(handle1.uuid, handle2.uuid)
+
+            # Close the MDF file
+            self.service.Close(handle1, None)
+            self.service.Close(handle2, None)


### PR DESCRIPTION
This pull request includes several updates to the `external_data_reader.py` file to improve the handling of gRPC context and error reporting, as well as the addition of a new development container configuration for Jupyter. The most important changes include the use of `grpc.ServicerContext` for context parameters, improved error handling, and the addition of a mock servicer context for testing.

### Updates to gRPC context and error handling:

* [`external_data_reader.py`](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L25-R81): Changed context parameters from `dict` to `grpc.ServicerContext` and replaced error handling with `context.abort` to provide more detailed gRPC error responses. [[1]](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L25-R81) [[2]](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L135-R143) [[3]](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L151-R161) [[4]](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L198-R252)
* [`external_data_reader.py`](diffhunk://#diff-ef838e0758e893d33680b4e5bf6c9fc956388839b4442fd3000b12761b190bd3L315-R364): Added type annotations to several methods for better type checking and readability.

### New development container configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R49): Added a new development container configuration for Jupyter, including necessary extensions and settings for Python development.

### Testing improvements:

* [`test/mock_servicer_context.py`](diffhunk://#diff-09fc07b4dcd08754161d6c600103280bdad54084682ea4a26d1acfe8d84b88ceR1-R78): Added a `MockServicerContext` class to facilitate testing of gRPC services.