### PR TITLE
fix: adjust read of version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Extract version number
         run: |
-          VERSION=$(grep -oP '(?<=__version__ = ")[^"]+' __init__.py)
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
This pull request updates the way the version number is extracted in the Docker build workflow to improve reliability and accuracy. The workflow now reads the version directly from `pyproject.toml` using Python's `tomllib` instead of parsing `__init__.py`.

**Build process improvements:**

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L18-R18): Changed the version extraction step to use Python's `tomllib` to read the version from `pyproject.toml`, replacing the previous method that used a regular expression on `__init__.py`.