### PR TITLE
feat: mark master channel as independent and update some chore infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ uv sync --group dev
 uv run python -m unittest discover tests
 ```
 
+### Run Plugin Locally
+
+Use an explicit IPv4 bind address on Windows to avoid IPv6 bind issues:
+
+```bash
+uv run asam-ods-exd-api-mdf4 --bind-address 127.0.0.1 --port 50051
+```
+
+Stop the server with `Ctrl+C`. A non-zero exit code after interruption is expected.
+
 ### Code Quality
 
 ```bash

--- a/external_data_file.py
+++ b/external_data_file.py
@@ -307,7 +307,12 @@ class ExternalDataFile(ExdFileInterface):
         return ods.DataTypeEnum.DT_DOUBLE
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run plugin server entry point."""
     from ods_exd_api_box import serve_plugin
 
     serve_plugin(file_type_name="MDF4", file_type_factory=ExternalDataFile.create, file_type_file_patterns=["*.mf4"])
+
+
+if __name__ == "__main__":
+    main()

--- a/external_data_file.py
+++ b/external_data_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, override
 
 from asammdf import MDF
@@ -20,25 +21,32 @@ class ExternalDataFile(ExdFileInterface):
 
     @override
     def __init__(self, file_path: str, parameters: str = ""):
+        self._log = logging.getLogger(__name__)
+
+        self._log.debug("Initializing ExternalDataFile with path: %s and parameters: %s", file_path, parameters)
         self.file_path = file_path
         self.parameters = parameters
         self.mdf4 = MDF(file_path)
+        self._log.debug("ExternalDataFile initialized")
 
     @override
     def close(self) -> None:
         """Close the external data file."""
         self.mdf4.close()
+        self._log.debug("ExternalDataFile closed")
 
     @override
     def fill_structure(self, structure: exd_api.StructureResult) -> None:
         """Fill the structure of the external data file."""
         mdf4 = self.mdf4
+        self._log.debug("Building structure for file: %s", self.file_path)
 
         start_time_ods = mdf4.start_time.strftime("%Y%m%d%H%M%S%f")
 
         structure.attributes.variables["start_time"].string_array.values.append(start_time_ods)
         self.__add_file_header(mdf4.header, structure.attributes)  # type: ignore
 
+        self._log.debug("Found %d groups in MDF", len(mdf4.groups))
         for group_index, group in enumerate(mdf4.groups):
             new_group = exd_api.StructureResult.Group()
             new_group.name = (
@@ -50,24 +58,46 @@ class ExternalDataFile(ExdFileInterface):
             new_group.attributes.variables["description"].string_array.values.append(group.channel_group.comment)
             new_group.attributes.variables["measurement_begin"].string_array.values.append(start_time_ods)
 
+            independent_added = False
             for channel_index, channel in enumerate(group.channels):
                 new_channel = exd_api.StructureResult.Channel()
                 new_channel.name = channel.name
                 new_channel.id = channel_index
                 new_channel.data_type = self.__get_channel_data_type(channel)  # type: ignore
                 new_channel.unit_string = channel.unit
-                if channel.comment is not None and "" != channel.comment:
+                if channel.comment is not None and "" != channel.comment: # type: ignore
                     new_channel.attributes.variables["description"].string_array.values.append(channel.comment)
-                if 0 == channel_index:
-                    new_channel.attributes.variables["independent"].long_array.values.append(1)
+                if 2 == channel.channel_type: # MASTER channel
+                    if not independent_added:
+                        new_channel.attributes.variables["independent"].long_array.values.append(1)
+                        independent_added = True
+                    else:
+                        self._log.warning(
+                            "Group %s has more than one master channel. Only the first will be marked as independent.",
+                            new_group.name,
+                        )
                 new_group.channels.append(new_channel)
 
             structure.groups.append(new_group)
+            self._log.debug(
+                "Added group id=%d name=%s channels=%d rows=%d",
+                new_group.id,
+                new_group.name,
+                len(new_group.channels),
+                new_group.number_of_rows,
+            )
 
     @override
     def get_values(self, request: exd_api.ValuesRequest) -> exd_api.ValuesResult:
         """Get values from the external data file."""
         mdf4 = self.mdf4
+        self._log.debug(
+            "GetValues request group_id=%d start=%d limit=%d channel_count=%d",
+            request.group_id,
+            request.start,
+            request.limit,
+            len(request.channel_ids),
+        )
 
         if request.group_id < 0 or request.group_id >= len(mdf4.groups):
             raise ValueError(f"Invalid group id {request.group_id}!")
@@ -81,6 +111,7 @@ class ExternalDataFile(ExdFileInterface):
         end_index = request.start + request.limit
         if end_index >= nr_of_rows:
             end_index = nr_of_rows
+        self._log.debug("Reading rows in range [%d, %d) out of %d", request.start, end_index, nr_of_rows)
 
         channels_to_load = []
         for channel_id in request.channel_ids:
@@ -151,6 +182,7 @@ class ExternalDataFile(ExdFileInterface):
 
             rv.channels.append(new_channel_values)
 
+        self._log.debug("GetValues returning %d channels", len(rv.channels))
         return rv
 
     def __add_file_header(self, header: HeaderBlock | None, attributes: Any) -> None:

--- a/external_data_file.py
+++ b/external_data_file.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, override
+from typing import Any, cast, override
 
 from asammdf import MDF
 from asammdf.blocks.v4_blocks import Channel, ChannelConversion, HeaderBlock
@@ -48,26 +48,29 @@ class ExternalDataFile(ExdFileInterface):
 
         self._log.debug("Found %d groups in MDF", len(mdf4.groups))
         for group_index, group in enumerate(mdf4.groups):
+            group_any = cast(Any, group)
             new_group = exd_api.StructureResult.Group()
             new_group.name = (
-                group.channel_group.acq_name if group.channel_group.acq_name is not None else f"Group {group_index}"
+                group_any.channel_group.acq_name
+                if group_any.channel_group.acq_name is not None
+                else f"Group {group_index}"
             )  # type: ignore
             new_group.id = group_index
-            new_group.total_number_of_channels = len(group.channels)
-            new_group.number_of_rows = group.channel_group.cycles_nr
-            new_group.attributes.variables["description"].string_array.values.append(group.channel_group.comment)
+            new_group.total_number_of_channels = len(group_any.channels)
+            new_group.number_of_rows = group_any.channel_group.cycles_nr
+            new_group.attributes.variables["description"].string_array.values.append(group_any.channel_group.comment)
             new_group.attributes.variables["measurement_begin"].string_array.values.append(start_time_ods)
 
             independent_added = False
-            for channel_index, channel in enumerate(group.channels):
+            for channel_index, channel in enumerate(group_any.channels):
                 new_channel = exd_api.StructureResult.Channel()
                 new_channel.name = channel.name
                 new_channel.id = channel_index
                 new_channel.data_type = self.__get_channel_data_type(channel)  # type: ignore
                 new_channel.unit_string = channel.unit
-                if channel.comment is not None and "" != channel.comment: # type: ignore
+                if channel.comment is not None and "" != channel.comment:  # type: ignore
                     new_channel.attributes.variables["description"].string_array.values.append(channel.comment)
-                if 2 == channel.channel_type: # MASTER channel
+                if 2 == channel.channel_type:  # MASTER channel
                     if not independent_added:
                         new_channel.attributes.variables["independent"].long_array.values.append(1)
                         independent_added = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = ["external_data_file"]
 
 [project]
 name = "asam-ods-exd-api-mdf4"
-version = "1.0.0"
+version = "1.1.0"
 description = "ASAM ODS EXD API implementation to read external data from MDF4 files."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -18,8 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "asammdf>=7.0.0",
-    "ods-exd-api-box>=1.3.0,<2.0.0",
+    "asammdf>=8.8.20",
+    "ods-exd-api-box>=1.5.0,<2.0.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "coverage>=7.0",
     "jupyterlab>=4.0",
     "mypy>=1.5",
+    "pytest>=9.1.1",
     "ruff>=0.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dev = [
     "mypy>=1.5",
     "pytest>=9.1.1",
     "ruff>=0.1.0",
+    "types-grpcio>=1.0.0.20260614",
+    "types-protobuf>=7.34.1.20260518",
 ]
 
 [project.urls]
@@ -50,9 +52,6 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 no_implicit_optional = true
 exclude = '(^|/)(build|\.venv|\.mypy_cache)(/|$)'
-
-[[tool.mypy.overrides]]
-ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "asammdf.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,16 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/peak-solution/asam_ods_exd_api_mdf4"
 
+[project.scripts]
+asam-ods-exd-api-mdf4 = "external_data_file:main"
+
 [tool.ruff]
 line-length = 119
 target-version = "py314"
 extend-exclude = ["*.ipynb"]
+
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]

--- a/tests/test_asammdf_reader.py
+++ b/tests/test_asammdf_reader.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+from asammdf import MDF
+
+
+class TestAsammdfReader(unittest.TestCase):
+    def test_cn_type(self):
+        main_file_path = Path.joinpath(Path(__file__).parent.resolve(), "..", "data", "simple.mf4")
+
+        with MDF(main_file_path) as mdf:
+            for group in mdf.groups:
+                for channel in group.channels:
+                    self.assertIsNotNone(channel.name)
+                    self.assertIsNotNone(channel.unit)
+
+                    cn_type = channel.channel_type
+                    print(f"Channel: {channel.name}, Type: {cn_type}")
+
+                    assert (channel.name == "time" and cn_type == 2) or cn_type != 2

--- a/tests/test_example_files.py
+++ b/tests/test_example_files.py
@@ -34,7 +34,9 @@ class TestExampleFiles(unittest.TestCase):
             return False
         if not channel.attributes.variables:
             return False
-        independent_attr: ods.ContextVariables.VariablesEntry | None = channel.attributes.variables.get("independent")
+        independent_attr: ods.ContextVariables.ContextVariableValue | None = channel.attributes.variables.get(
+            "independent"
+        )
         if not independent_attr:
             return False
 

--- a/tests/test_example_files.py
+++ b/tests/test_example_files.py
@@ -7,6 +7,7 @@ from glob import glob
 from ods_exd_api_box import ExternalDataReader, FileHandlerRegistry, exd_api, ods
 
 from external_data_file import ExternalDataFile
+from tests.mock_servicer_context import MockServicerContext
 
 # pylint: disable=E1101
 
@@ -17,31 +18,29 @@ class TestExampleFiles(unittest.TestCase):
     def setUp(self):
         """Register ExternalDataFile handler before each test."""
         FileHandlerRegistry.register(file_type_name="test", factory=ExternalDataFile)
+        self.mock_context = MockServicerContext()
 
-    def __load_structure(self, example_file_uri):
+    def __load_structure(self, example_file_uri: str):
         service = ExternalDataReader()
-        handle = service.Open(exd_api.Identifier(url=example_file_uri, parameters=""), None)
+        handle = service.Open(exd_api.Identifier(url=example_file_uri, parameters=""), self.mock_context)
         try:
-            structure = service.GetStructure(exd_api.StructureRequest(handle=handle), None)
+            structure = service.GetStructure(exd_api.StructureRequest(handle=handle), self.mock_context)
             return structure
         finally:
-            service.Close(handle, None)
+            service.Close(handle, self.mock_context)
 
     def test_files(self):
-        """test loops over all files and checks if values do match info in structure"""
+        """Parameterized test over all example files using unittest subTest."""
         example_files_folder = pathlib.Path.joinpath(pathlib.Path(__file__).parent.resolve(), "..", "data", "examples")
         example_files = [y for x in os.walk(example_files_folder) for y in glob(os.path.join(x[0], "*.mf4"))]
+        self.assertGreater(len(example_files), 0, "No .mf4 example files found")
 
-        failed = False
         for example_file in example_files:
-            example_file_uri = pathlib.Path(example_file).absolute().resolve().as_uri()
-            try:
+            example_file_path = pathlib.Path(example_file)
+            example_file_uri = example_file_path.absolute().resolve().as_uri()
+            relative_example_file = example_file_path.relative_to(example_files_folder)
+            with self.subTest(example_file=str(relative_example_file)):
                 self.__check_file_including_bulk(example_file_uri)
-            except Exception as e:
-                print(f"FAILED: {e}")
-                failed = True
-
-        self.assertFalse(failed, "At least one file failed")
 
     def test_file(self):
         """Check a single file"""
@@ -50,7 +49,7 @@ class TestExampleFiles(unittest.TestCase):
         example_file_uri = pathlib.Path(example_file).absolute().resolve().as_uri()
         self.__check_file_including_bulk(example_file_uri)
 
-    def __check_file_including_bulk(self, example_file_uri):
+    def __check_file_including_bulk(self, example_file_uri: str):
         print(f"URI: {example_file_uri}")
         self.log.info("Retrieve structure")
         structure = self.__load_structure(example_file_uri)
@@ -59,10 +58,10 @@ class TestExampleFiles(unittest.TestCase):
 
         self.log.info("Check bulk load")
         service = ExternalDataReader()
-        handle = service.Open(exd_api.Identifier(url=example_file_uri, parameters=""), None)
+        handle = service.Open(exd_api.Identifier(url=example_file_uri, parameters=""), self.mock_context)
         try:
             for group in structure.groups:
-                channel_ids = []
+                channel_ids: list[int] = []
                 for channel in group.channels:
                     channel_ids.append(channel.id)
                 values = service.GetValues(
@@ -73,7 +72,7 @@ class TestExampleFiles(unittest.TestCase):
                         limit=group.number_of_rows + 10,
                         channel_ids=channel_ids,
                     ),
-                    None,
+                    self.mock_context,
                 )
                 for values_channel_index, values_channel in enumerate(values.channels):
                     structure_channel = group.channels[values_channel_index]
@@ -118,4 +117,4 @@ class TestExampleFiles(unittest.TestCase):
                     else:
                         self.assertFalse(True, f"Unknown type {values_channel.values.data_type}")
         finally:
-            service.Close(handle, None)
+            service.Close(handle, self.mock_context)

--- a/tests/test_example_files.py
+++ b/tests/test_example_files.py
@@ -29,6 +29,18 @@ class TestExampleFiles(unittest.TestCase):
         finally:
             service.Close(handle, self.mock_context)
 
+    def __is_independent_channel(self, channel: exd_api.StructureResult.Channel) -> bool:
+        if not channel.attributes:
+            return False
+        if not channel.attributes.variables:
+            return False
+        independent_attr: ods.ContextVariables.VariablesEntry | None = channel.attributes.variables.get("independent")
+        if not independent_attr:
+            return False
+
+        assert independent_attr.HasField("long_array"), "Independent attribute should be a long_array"
+        return independent_attr.long_array.values[0] == 1
+
     def test_files(self):
         """Parameterized test over all example files using unittest subTest."""
         example_files_folder = pathlib.Path.joinpath(pathlib.Path(__file__).parent.resolve(), "..", "data", "examples")
@@ -62,8 +74,13 @@ class TestExampleFiles(unittest.TestCase):
         try:
             for group in structure.groups:
                 channel_ids: list[int] = []
+                independent_count = 0
                 for channel in group.channels:
                     channel_ids.append(channel.id)
+                    if self.__is_independent_channel(channel):
+                        independent_count += 1
+                self.assertLessEqual(independent_count, 1, f"Group {group.name} has more than one independent channel")
+
                 values = service.GetValues(
                     exd_api.ValuesRequest(
                         handle=handle,

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -25,6 +25,7 @@ import tempfile
 import unittest
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 from asammdf import MDF, Signal
@@ -75,14 +76,19 @@ class TestRoundtrip(unittest.TestCase):
         return self.service.Open(exd_api.Identifier(url=_uri(path), parameters=""), None)
 
     def _structure(self, handle) -> exd_api.StructureResult:
-        return self.service.GetStructure(exd_api.StructureRequest(handle=handle), None)
+        return cast(exd_api.StructureResult, self.service.GetStructure(exd_api.StructureRequest(handle=handle), None))
 
     def _values(
         self, handle, group_id: int, channel_ids: list, start: int = 0, limit: int = 9999, context=None
     ) -> exd_api.ValuesResult:
-        return self.service.GetValues(
-            exd_api.ValuesRequest(handle=handle, group_id=group_id, channel_ids=channel_ids, start=start, limit=limit),
-            context,
+        return cast(
+            exd_api.ValuesResult,
+            self.service.GetValues(
+                exd_api.ValuesRequest(
+                    handle=handle, group_id=group_id, channel_ids=channel_ids, start=start, limit=limit
+                ),
+                context,
+            ),
         )
 
     def _assert_floats(self, actual, expected, places: int = 5):

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "asam-ods-exd-api-mdf4"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "asammdf" },
@@ -107,8 +107,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asammdf", specifier = ">=7.0.0" },
-    { name = "ods-exd-api-box", specifier = ">=1.3.0,<2.0.0" },
+    { name = "asammdf", specifier = ">=8.8.20" },
+    { name = "ods-exd-api-box", specifier = ">=1.5.0,<2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -124,7 +124,7 @@ dev = [
 
 [[package]]
 name = "asammdf"
-version = "8.8.1"
+version = "8.8.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "canmatrix", extra = ["arxml"] },
@@ -140,12 +140,12 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zstd" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3e/4960e7c8a609b4676e9c0b9feaef47b8054b97c43a95e1b6a1d1b15202d4/asammdf-8.8.1.tar.gz", hash = "sha256:71539bc35eaa1446518e2e083816ce4099c1c422a933ec0852c6b4d4ccfe390a", size = 11657678, upload-time = "2026-04-09T09:41:31.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/a4/37ce5243a2b845657280f6599308f2ff0c3e6aaf3673508f612602195790/asammdf-8.8.20.tar.gz", hash = "sha256:688bf44dbe77e3b7b1d710b4606af1fe459053ebfad09b0ed698ca5984c2ee56", size = 11660649, upload-time = "2026-07-01T09:51:44.575Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/f3/6542cd0bf0903de1e0bdd9c689bb28c264d29bbe0c4413152488d10ce71a/asammdf-8.8.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc9e013025134a2e0cc91ef2329352bce2df31bfc581cb9b4424012a07ac774c", size = 1303384, upload-time = "2026-04-09T09:41:24.983Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d5/30d1d63058b0cea7f1daac0d887bb4c8676e04ff30379cd27d389f795046/asammdf-8.8.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb3a9ea5eeed0719b63df76403d8884b9014e3e1bd57274cee71aa6e69aae276", size = 1347958, upload-time = "2026-04-09T09:41:27.143Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/80/9909ef534d8e4f95ccf7573ce0ad666f9f5347542429a81d763cfb6f3e9f/asammdf-8.8.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:089e19e1df72bfdecd4478a6b24ee000e1d635897e846a707c62cc645d938a95", size = 1370957, upload-time = "2026-04-09T09:41:28.361Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0e/d131623e3c5adcb9d7a373d7e6a1398afeec114071dc3570b663abcfdc3c/asammdf-8.8.1-cp310-abi3-win_amd64.whl", hash = "sha256:7a67a72b31852b3a40171324b0938ee92d5d46d2a004ed5a5ad45e7d58814966", size = 1231669, upload-time = "2026-04-09T09:41:29.893Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/43/2882a1212be53490694ddf69b1a54340bc55c071da77a4881715ea602163/asammdf-8.8.20-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:1d594dece0ae22f00ae7d1d0d10a9c88bf42c46b518bead8cf92b00b9e08d7df", size = 1307092, upload-time = "2026-07-01T09:51:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0d/cbc33a0b2badf0c2394b47b62f6326621f922f959b1d07c7fc64e4d49a02/asammdf-8.8.20-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:595034c682a2f50c35a8481227201db47a5860ce8322f3f901531a9185eb07d1", size = 1350579, upload-time = "2026-07-01T09:51:39.957Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2d/3fd43348ca049e01a9e834cf7ab59b3d8324acc9a80b671262b660fcd654/asammdf-8.8.20-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf02822c6c44c2c4b11fd43f33fc1d33de763a035230a07504b13ad5e66341a7", size = 1373575, upload-time = "2026-07-01T09:51:41.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/10/ef55f83c85999571f59f1a8af9b8ce48dab7158e84bb797c3b8bd3a3a6b2/asammdf-8.8.20-cp310-abi3-win_amd64.whl", hash = "sha256:64caf71c25fc7e4974294b098a8ad20204b395d77cbf376bc6d367f0bdbfb043", size = 1373423, upload-time = "2026-07-01T09:51:42.947Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,8 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-grpcio" },
+    { name = "types-protobuf" },
 ]
 
 [package.metadata]
@@ -116,6 +118,8 @@ dev = [
     { name = "mypy", specifier = ">=1.5" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "types-grpcio", specifier = ">=1.0.0.20260614" },
+    { name = "types-protobuf", specifier = ">=7.34.1.20260518" },
 ]
 
 [[package]]
@@ -1753,6 +1757,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-grpcio"
+version = "1.0.0.20260614"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/1c/e299150827a2224fe9ddb59e9f789f0eb8e72e0befc23fd47195024311fa/types_grpcio-1.0.0.20260614.tar.gz", hash = "sha256:e86d1aabb7e7eedae487c3ac10e010a13d5db1fd350e766562053af557366aab", size = 15063, upload-time = "2026-06-14T06:23:33.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/f5/a8b8ca4d891bc4e835ef758a8fb50c7539c7f45bc0e42fae2b847cbc59b7/types_grpcio-1.0.0.20260614-py3-none-any.whl", hash = "sha256:050472cb4ef329ae8fe20278c62bc0da5b961aad3dd889cc35f6e0c70d368dae", size = 15629, upload-time = "2026-06-14T06:23:32.616Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.34.1.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,7 @@ dev = [
     { name = "coverage" },
     { name = "jupyterlab" },
     { name = "mypy" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -113,6 +114,7 @@ dev = [
     { name = "coverage", specifier = ">=7.0" },
     { name = "jupyterlab", specifier = ">=4.0" },
     { name = "mypy", specifier = ">=1.5" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.1.0" },
 ]
 
@@ -564,6 +566,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1311,6 +1322,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1402,6 +1422,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several improvements and updates across the codebase, focusing on enhanced logging, stricter validation, improved test coverage, and dependency updates. The changes add detailed logging to `ExternalDataFile`, enforce correct master channel marking, improve test robustness, and update dependencies and configuration for better maintainability.

**Core functionality and logging improvements:**

* Added detailed logging throughout `external_data_file.py` for key operations such as initialization, structure building, and value retrieval, making debugging and tracing easier. [[1]](diffhunk://#diff-89d6ec268f8c4579ee5441bf9963c1acf5adcc36b1891e48dda44c41e611a5b2L5-R6) [[2]](diffhunk://#diff-89d6ec268f8c4579ee5441bf9963c1acf5adcc36b1891e48dda44c41e611a5b2R24-R103) [[3]](diffhunk://#diff-89d6ec268f8c4579ee5441bf9963c1acf5adcc36b1891e48dda44c41e611a5b2R117) [[4]](diffhunk://#diff-89d6ec268f8c4579ee5441bf9963c1acf5adcc36b1891e48dda44c41e611a5b2R188)
* Improved master channel detection logic: now only the first master channel in a group is marked as independent, with warnings logged if more than one is found.
* Refactored entry point: added a `main()` function for the plugin server and registered a CLI script in `pyproject.toml`. [[1]](diffhunk://#diff-89d6ec268f8c4579ee5441bf9963c1acf5adcc36b1891e48dda44c41e611a5b2L275-R318) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21-R49)

**Testing enhancements:**

* Refactored and expanded tests in `tests/test_example_files.py` to use `unittest` subtests, check for at most one independent channel per group, and use a mock gRPC context for more realistic testing. [[1]](diffhunk://#diff-f1f7fd72aaec5ed4a575dbe5239f95fc07c61867aede9a2dcf9589ed2aa17851R21-L44) [[2]](diffhunk://#diff-f1f7fd72aaec5ed4a575dbe5239f95fc07c61867aede9a2dcf9589ed2aa17851L62-R85) [[3]](diffhunk://#diff-f1f7fd72aaec5ed4a575dbe5239f95fc07c61867aede9a2dcf9589ed2aa17851L121-R139)
* Added a new test in `tests/test_asammdf_reader.py` to verify channel types and names in MDF files.
* Improved type safety in tests by using `cast` for gRPC results in `tests/test_roundtrip.py`. [[1]](diffhunk://#diff-ddcb1394c627d8e3a7708c584685352159fb6366dde5dabaaa724811cfcd4be2R28) [[2]](diffhunk://#diff-ddcb1394c627d8e3a7708c584685352159fb6366dde5dabaaa724811cfcd4be2L78-R91)

**Dependency and configuration updates:**

* Updated dependencies in `pyproject.toml` to require newer versions of `asammdf`, `ods-exd-api-box`, and added type stubs for development.
* Added and configured Dependabot for automated dependency updates for GitHub Actions, pip, and Docker. (.github/dependabot.yml)
* Enhanced `pyproject.toml` with additional dev dependencies, CLI script registration, and improved code formatting configuration. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21-R49) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L53-L55)

**Documentation:**

* Updated `README.md` with instructions for running the plugin locally, including a Windows-specific note for binding to IPv4.

These changes collectively improve maintainability, observability, and testability of the codebase.