### PR TITLE
chore: cleanup development process to avoid pushing container without release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      - dev
+    tags:
+      - "v*"
   # ...existing trigger configurations...
 
 jobs:
@@ -22,6 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -33,7 +37,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/asam-ods-exd-api-mdf4:latest
             ghcr.io/${{ github.repository_owner }}/asam-ods-exd-api-mdf4:${{ env.VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Extract version number
         run: |
@@ -19,17 +19,17 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = ["external_data_file"]
 
 [project]
 name = "asam-ods-exd-api-mdf4"
-version = "1.1.0"
+version = "1.2.0"
 description = "ASAM ODS EXD API implementation to read external data from MDF4 files."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
This pull request updates the CI/CD workflows and increments the project version. The main changes include expanding the Docker build workflow to support additional branches and tags, upgrading GitHub Actions dependencies to their latest major versions, and bumping the project version to `1.2.0`.

**Workflow improvements and dependency upgrades:**

* Updated `.github/workflows/docker-build.yml` to also trigger on pushes to the `dev` branch and on version tags matching `v*`, and upgraded all used GitHub Actions to their latest major versions (`actions/checkout@v7`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7`). The Docker login and image push steps are now conditional on tag builds, improving release handling.
* Upgraded `actions/setup-python` to v6 in `.github/workflows/python-package.yml` for improved Python environment setup.

**Version bump:**

* Increased the project version in `pyproject.toml` from `1.1.0` to `1.2.0` to reflect new changes and workflow updates.