### PR TITLE
feat: in addition to MASTER also mark VIRTUAL_MASTER channels as inde…

### DIFF
--- a/external_data_file.py
+++ b/external_data_file.py
@@ -70,14 +70,17 @@ class ExternalDataFile(ExdFileInterface):
                 new_channel.unit_string = channel.unit
                 if channel.comment is not None and "" != channel.comment:  # type: ignore
                     new_channel.attributes.variables["description"].string_array.values.append(channel.comment)
-                if 2 == channel.channel_type:  # MASTER channel
+                if channel.channel_type in (2, 3):  # MASTER or VIRTUAL_MASTE channel
                     if not independent_added:
                         new_channel.attributes.variables["independent"].long_array.values.append(1)
                         independent_added = True
                     else:
                         self._log.warning(
-                            "Group %s has more than one master channel. Only the first will be marked as independent.",
+                            "Group %s has more than one master channel. Only the first will be marked as independent. "
+                            "'%s' (type=%s) is ignored.",
                             new_group.name,
+                            new_channel.name,
+                            channel.channel_type,
                         )
                 new_group.channels.append(new_channel)
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -531,6 +531,35 @@ class TestRoundtrip(unittest.TestCase):
         finally:
             self.service.Close(handle, None)
 
+    def test_virtual_master_channel(self):
+        """A virtual master channel (channel_type=3) must be marked independent and
+        return sample indices [0, 1, 2, ...] as DT_DOUBLE values."""
+        vals = np.array([10.0, 20.0, 30.0], np.float64)
+        sig = Signal(samples=vals, timestamps=[0.5, 1.5, 3.0], name="speed", unit="m/s")
+        with MDF(version="4.10") as mdf:
+            mdf.append([sig], common_timebase=True)
+            mdf.groups[0].channels[0].channel_type = 3  # VIRTUAL_MASTER
+            path = self._save(mdf, "virtual_master.mf4")
+        handle = self._open(path)
+        try:
+            structure = self._structure(handle)
+            grp = structure.groups[0]
+            time_ch = grp.channels[0]
+            self.assertEqual(time_ch.name, "time")
+            self.assertIn("independent", time_ch.attributes.variables)
+            self.assertEqual(time_ch.attributes.variables["independent"].long_array.values[0], 1)
+            self.assertEqual(time_ch.data_type, ods.DataTypeEnum.DT_DOUBLE)
+
+            data_ch = grp.channels[1]
+            self.assertNotIn("independent", data_ch.attributes.variables)
+
+            # Virtual master yields sample indices as doubles
+            result = self._values(handle, 0, [0, 1])
+            self._assert_floats(result.channels[0].values.double_array.values, [0.0, 1.0, 2.0])
+            self._assert_floats(result.channels[1].values.double_array.values, vals.tolist())
+        finally:
+            self.service.Close(handle, None)
+
     # ==================================================================
     # Group metadata
     # ==================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "asam-ods-exd-api-mdf4"
-version = "1.1.0"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "asammdf" },
@@ -107,7 +107,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asammdf", specifier = ">=8.8.20" },
+    { name = "asammdf", specifier = ">=8.8.20,<9.0.0" },
     { name = "ods-exd-api-box", specifier = ">=1.5.0,<2.0.0" },
 ]
 


### PR DESCRIPTION
This pull request updates the handling of "virtual master" channels to ensure they are treated similarly to master channels and adds a dedicated test to verify this behavior. The main changes are:

**Feature enhancements:**

* Updated `external_data_file.py` to mark channels with `channel_type` 3 (VIRTUAL_MASTER) as independent, just like master channels (type 2), and improved the warning message to include channel details.

**Testing improvements:**

* Added a new test `test_virtual_master_channel` in `tests/test_roundtrip.py` to verify that virtual master channels are marked as independent, return sample indices as double values, and that only the correct channel is marked as independent.…pendent