### PR TITLE
feat: add support for multiple string encodings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: "dev"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(ci)"
@@ -13,6 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: "dev"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
@@ -22,6 +24,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: "dev"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(docker)"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "CCBLOCK",
         "DCOMPLEX",
         "dtypes",
+        "frompyfunc",
         "tobytes"
     ],
     "python.testing.unittestArgs": [

--- a/external_data_file.py
+++ b/external_data_file.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast, override
 
+import numpy as np
 from asammdf import MDF
 from asammdf.blocks.v4_blocks import Channel, ChannelConversion, HeaderBlock
 from ods_exd_api_box import ExdFileInterface, exd_api, ods
@@ -12,6 +13,12 @@ from ods_exd_api_box import ExdFileInterface, exd_api, ods
 
 class ExternalDataFile(ExdFileInterface):
     """Class for handling MDF4 files."""
+
+    # Pre-built decoders for string encodings to avoid recreation on every call
+    _latin1_decoder = np.frompyfunc(lambda b: b.decode("latin-1"), 1, 1)
+    _utf8_decoder = np.frompyfunc(lambda b: b.decode("utf-8"), 1, 1)
+    _utf16le_decoder = np.frompyfunc(lambda b: (b if len(b) % 2 == 0 else b + b"\x00").decode("utf-16-le"), 1, 1)
+    _utf16be_decoder = np.frompyfunc(lambda b: (b if len(b) % 2 == 0 else b + b"\x00").decode("utf-16-be"), 1, 1)
 
     @classmethod
     @override
@@ -177,7 +184,7 @@ class ExternalDataFile(ExdFileInterface):
                     real_values_d.append(complex_value.imag)
                 new_channel_values.values.double_array.values[:] = real_values_d
             elif channel_datatype == ods.DataTypeEnum.DT_STRING:
-                new_channel_values.values.string_array.values[:] = section
+                ExternalDataFile._assign_strings(new_channel_values.values.string_array, section, channel)
             elif channel_datatype == ods.DataTypeEnum.DT_BYTESTR:
                 for item in section:
                     new_channel_values.values.bytestr_array.values.append(item.tobytes())
@@ -190,6 +197,28 @@ class ExternalDataFile(ExdFileInterface):
 
         self._log.debug("GetValues returning %d channels", len(rv.channels))
         return rv
+
+    @staticmethod
+    def _assign_strings(target: ods.StringArray, section: np.ndarray, channel: Any) -> None:
+        if section.dtype.kind == "S":
+            if channel.data_type == 6:
+                # Latin-1 (ISO-8859-1) encoding
+                target.values[:] = ExternalDataFile._latin1_decoder(section).tolist()
+                return
+            elif channel.data_type == 7:
+                # UTF-8 encoding
+                target.values[:] = ExternalDataFile._utf8_decoder(section).tolist()
+                return
+            elif channel.data_type == 8:
+                # UTF-16 little-endian encoding
+                target.values[:] = ExternalDataFile._utf16le_decoder(section).tolist()
+                return
+            elif channel.data_type == 9:
+                # UTF-16 big-endian encoding
+                target.values[:] = ExternalDataFile._utf16be_decoder(section).tolist()
+                return
+
+        target.values[:] = section
 
     def __add_file_header(self, header: HeaderBlock | None, attributes: Any) -> None:
         if header is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = ["external_data_file"]
 
 [project]
 name = "asam-ods-exd-api-mdf4"
-version = "1.2.3"
+version = "1.2.4"
 description = "ASAM ODS EXD API implementation to read external data from MDF4 files."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_exd_api_datatypes.py
+++ b/tests/test_exd_api_datatypes.py
@@ -315,3 +315,69 @@ class TestDataTypes(unittest.TestCase):
                 self.assertSequenceEqual(values.channels[1].values.long_array.values, [2, 4])
             finally:
                 service.Close(handle, None)
+
+    def test_string_encodings_get_values(self):
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            file_path = os.path.join(temporary_directory_name, "string_encodings_test.mf4")
+
+            with MDF(version="4.10", file_comment="string_encodings_test.mf4") as mdf4:
+                mdf4.start_time = datetime.now()
+
+                timestamps = [0, 1]
+                sigs = [
+                    Signal(
+                        samples=["Grüße", "façade"],
+                        timestamps=timestamps,
+                        comment="latin1 string data",
+                        name="latin1_data",
+                        unit="ns",
+                        encoding="latin-1",
+                    ),
+                    Signal(
+                        samples=["Grüße", "αβγ"],
+                        timestamps=timestamps,
+                        comment="utf8 string data",
+                        name="utf8_data",
+                        unit="ns",
+                        encoding="utf-8",
+                    ),
+                    Signal(
+                        samples=["Grüße", "漢字"],
+                        timestamps=timestamps,
+                        comment="utf16le string data",
+                        name="utf16le_data",
+                        unit="ns",
+                        encoding="utf-16-le",
+                    ),
+                    Signal(
+                        samples=["Grüße", "漢字"],
+                        timestamps=timestamps,
+                        comment="utf16be string data",
+                        name="utf16be_data",
+                        unit="ns",
+                        encoding="utf-16-be",
+                    ),
+                ]
+                mdf4.append(sigs, comment="group_string_encodings", common_timebase=True)
+
+                mdf4.save(file_path, compression=2, overwrite=True)
+
+            service = ExternalDataReader()
+            handle = service.Open(exd_api.Identifier(url=Path(file_path).resolve().as_uri(), parameters=""), None)
+            try:
+                structure = service.GetStructure(exd_api.StructureRequest(handle=handle), None)
+                self.assertEqual(len(structure.groups), 1)
+                self.assertEqual(len(structure.groups[0].channels), 5)
+                for channel in structure.groups[0].channels[1:]:
+                    self.assertEqual(channel.data_type, ods.DataTypeEnum.DT_STRING)
+
+                values = service.GetValues(
+                    exd_api.ValuesRequest(handle=handle, group_id=0, start=0, limit=2, channel_ids=[1, 2, 3, 4]), None
+                )
+                self.assertEqual([channel.id for channel in values.channels], [1, 2, 3, 4])
+                self.assertSequenceEqual(values.channels[0].values.string_array.values, ["Grüße", "façade"])
+                self.assertSequenceEqual(values.channels[1].values.string_array.values, ["Grüße", "αβγ"])
+                self.assertSequenceEqual(values.channels[2].values.string_array.values, ["Grüße", "漢字"])
+                self.assertSequenceEqual(values.channels[3].values.string_array.values, ["Grüße", "漢字"])
+            finally:
+                service.Close(handle, None)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -25,6 +25,7 @@ import tempfile
 import unittest
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import numpy as np
@@ -95,6 +96,15 @@ class TestRoundtrip(unittest.TestCase):
         self.assertEqual(len(actual), len(expected), f"length mismatch: got {len(actual)}, want {len(expected)}")
         for i, (a, e) in enumerate(zip(actual, expected)):
             self.assertAlmostEqual(float(a), float(e), places=places, msg=f"index {i}: {a} != {e}")
+
+    def _decode_string_samples(self, samples: np.ndarray, encoding: str) -> list[str]:
+        decoded = []
+        for item in samples:
+            payload = bytes(item).rstrip(b"\x00")
+            if encoding.startswith("utf-16") and len(payload) % 2 != 0:
+                payload += b"\x00"
+            decoded.append(payload.decode(encoding))
+        return decoded
 
     # ==================================================================
     # Scalar numeric types
@@ -259,6 +269,71 @@ class TestRoundtrip(unittest.TestCase):
             self.assertEqual(ch.data_type, ods.DataTypeEnum.DT_STRING)
             result = self._values(handle, 0, [1])
             self.assertSequenceEqual(list(result.channels[0].values.string_array.values), vals)
+        finally:
+            self.service.Close(handle, None)
+
+    def test_assign_strings_decodes_mdf_string_encodings(self):
+        cases = [
+            (6, "latin-1", ["Grüße", "façade"]),
+            (7, "utf-8", ["Grüße", "αβγ"]),
+            (8, "utf-16-le", ["Grüße", "漢字"]),
+            (9, "utf-16-be", ["Grüße", "漢字"]),
+        ]
+
+        for data_type, encoding, values in cases:
+            with self.subTest(data_type=data_type, encoding=encoding):
+                target = ods.StringArray()
+                section = np.array([value.encode(encoding).rstrip(b"\x00") for value in values])
+                channel = SimpleNamespace(data_type=data_type)
+
+                ExternalDataFile._assign_strings(target, section, channel)
+
+                self.assertSequenceEqual(list(target.values), values)
+
+    def test_string_multiencoding_roundtrip(self):
+        ts = [0.0, 1.0]
+        expected_values = [
+            ["Grüße", "façade"],
+            ["Grüße", "αβγ"],
+            ["Grüße", "漢字"],
+            ["Grüße", "漢字"],
+        ]
+        expected_data_types = [6, 7, 8, 9]
+        encodings = ["latin-1", "utf-8", "utf-16-le", "utf-16-be"]
+        sigs = [
+            Signal(samples=expected_values[0], timestamps=ts, name="latin1", encoding="latin-1"),
+            Signal(samples=expected_values[1], timestamps=ts, name="utf8", encoding="utf-8"),
+            Signal(samples=expected_values[2], timestamps=ts, name="utf16le", encoding="utf-16-le"),
+            Signal(samples=expected_values[3], timestamps=ts, name="utf16be", encoding="utf-16-be"),
+        ]
+        path = self._make_file(sigs, "strings_multi_encoding.mf4")
+
+        with MDF(path) as mdf:
+            channels = mdf.groups[0].channels[1:]
+            self.assertEqual([channel.data_type for channel in channels], expected_data_types)
+
+            signals = mdf.select([(None, 0, channel_id) for channel_id in [1, 2, 3, 4]], raw=False, copy_master=False)
+            for signal, expected, encoding in zip(signals, expected_values, encodings):
+                self.assertEqual(signal.samples.dtype.kind, "S")
+                decoded = []
+                for item in signal.samples:
+                    payload = bytes(item)
+                    if encoding.startswith("utf-16") and len(payload) % 2 != 0:
+                        payload += b"\x00"
+                    decoded.append(payload.decode(encoding))
+                self.assertSequenceEqual(decoded, expected)
+
+        handle = self._open(path)
+        try:
+            channels = self._structure(handle).groups[0].channels
+            self.assertEqual(len(channels), 5)
+            for channel in channels[1:]:
+                self.assertEqual(channel.data_type, ods.DataTypeEnum.DT_STRING)
+
+            result = self._values(handle, 0, [1, 2, 3, 4])
+            self.assertEqual([channel.id for channel in result.channels], [1, 2, 3, 4])
+            for channel_result, expected in zip(result.channels, expected_values):
+                self.assertSequenceEqual(list(channel_result.values.string_array.values), expected)
         finally:
             self.service.Close(handle, None)
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "asam-ods-exd-api-mdf4"
-version = "1.2.3"
+version = "1.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "asammdf" },


### PR DESCRIPTION
Update the version to 1.2.4 and enhance the `ExternalDataFile` class to support multiple string encodings. Include tests to verify the functionality of these encodings. Additionally, configure Dependabot to create pull requests targeting the development branch.